### PR TITLE
Added relativize_url

### DIFF
--- a/lib/jekyll/filters/url_filters.rb
+++ b/lib/jekyll/filters/url_filters.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "addressable/uri"
+require "pathname"
 
 module Jekyll
   module Filters
@@ -31,6 +32,20 @@ module Jekyll
         Addressable::URI.parse(
           parts.compact.map { |part| ensure_leading_slash(part.to_s) }.join
         ).normalize.to_s
+      end
+
+      # Produces a path relative to the current page. For example, if the path
+      # `/images/me.jpg` is supplied, then the result could be, `me.jpg`,
+      # `images/me.jpg` or `../../images/me.jpg` depending on whether the current
+      # page lives in `/images`, `/` or `/sub/dir/` respectively.
+      #
+      # input - a path relative to the project root
+      #
+      # Returns the supplied path relativized to the current page.
+      def relativize_url(input)
+        pageUrl = @context.registers[:page]["url"]
+        pageDir = Pathname(pageUrl).parent
+        Pathname(input).relative_path_from(pageDir).to_s
       end
 
       # Strips trailing `/index.html` from URLs to create pretty permalinks


### PR DESCRIPTION
Added a filter called `relativize_url` which generates URLs relative to the current page.

See discussion here: https://github.com/jekyll/jekyll/issues/6360

I'd be happy to add tests and docs, but would first like to hear if maintainers find this a worthwhile addition. 

Personally I find it incredibly useful as I no longer have to care about the path of the directory from which the content of `_site` is served (as opposed to using `relative_url`). Also, I don't need to mess with different `baseUrl` in development and production. Resulting HTML can even be viewed directly on disk (`file://...`). Granted, it's easy for users to put this filter in the `_plugins` directory manually.