### PR TITLE
Fix relativize_url for pretty permalinks

### DIFF
--- a/lib/jekyll/filters/url_filters.rb
+++ b/lib/jekyll/filters/url_filters.rb
@@ -44,8 +44,7 @@ module Jekyll
       def relativize_url(input)
         return if input.nil?
         input = ensure_leading_slash(input)
-        page_url = @context.registers[:page]["url"]
-        page_dir = Pathname(page_url).parent
+        page_dir = Pathname(@context.registers[:page]["dir"])
         Pathname(input).relative_path_from(page_dir).to_s
       end
 


### PR DESCRIPTION
I found your pull-request yesterday and really liked it (https://github.com/jekyll/jekyll/pull/6362). Unfortunately it was not successful because of the issue with the `permalink: pretty` setting, which would have been easy to solve and due to the missing willingness to accept the use case.

However, for the reference, I want to link my fix here.